### PR TITLE
Feat/20200303  use littlefs for mtd eeprom

### DIFF
--- a/drivers/include/mtd_spi_eeprom.h
+++ b/drivers/include/mtd_spi_eeprom.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2220 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_mtd_spi_eeprom mtd wrapper for spi_eeprom like at25xxx or M95xxx
+ * @ingroup     drivers_storage
+ * @brief       Driver for SPI-EEPROMs using mtd interface
+ *
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for mtd_spi_eeprom driver
+ *
+ * @author      Johannes Koster <johannes.koster@ml-pa.com>
+ */
+
+#ifndef MTD_SPI_EEPROM_H
+#define MTD_SPI_EEPROM_H
+
+#include <stdint.h>
+
+#include "at25xxx.h"
+#include "mtd.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @brief   Device descriptor for mtd_spi_eeprom device
+ *
+ * This is an extension of the @c mtd_dev_t struct
+ */
+typedef struct {
+    mtd_dev_t base;                    /**< inherit from mtd_dev_t object */
+    at25xxx_t *spi_eeprom;             /**< spi_eeprom dev descriptor */
+    const at25xxx_params_t *params; /**< params for spi_eeprom init */
+} mtd_spi_eeprom_t;
+
+
+/**
+ * @brief   EEPROMs handle sector erase internally so it's possible to directly
+ *          write to the EEPROM without erasing the sector first.
+ *          Attention: an erase call will therefore NOT touch the content,
+ *                     so disable this feature to ensure overriding the data.
+ */
+#ifndef MTD_SPI_EEPROM_SKIP_ERASE
+#define MTD_SPI_EEPROM_SKIP_ERASE (1)
+#endif
+
+/**
+ * @brief   spi_eeprom device operations table for mtd
+ */
+extern const mtd_desc_t mtd_spi_eeprom_driver;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MTD_SPI_EEPROM_H */
+/** @} */

--- a/drivers/mtd_spi_eeprom/Makefile
+++ b/drivers/mtd_spi_eeprom/Makefile
@@ -1,0 +1,3 @@
+MODULE = mtd_spi_eeprom
+
+include $(RIOTBASE)/Makefile.base

--- a/drivers/mtd_spi_eeprom/mtd_spi_eeprom.c
+++ b/drivers/mtd_spi_eeprom/mtd_spi_eeprom.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2220 ML!PA Consulting GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     drivers_mtd_spi_eeprom
+ * @{
+ *
+ * @file
+ * @brief       Driver for using spi eeprom (like AT25xxx, M95xxx, 25AAxxx, 25LCxxx,
+ *              CAT25xxx & BR25Sxxx) as mtd
+ *
+ * @author      Johannes Koster <johannes.koster@ml-pa.com>
+ *
+ * @}
+ */
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+#include "mtd.h"
+#include "mtd_spi_eeprom.h"
+#include "at25xxx.h"
+#include "at25xxx_params.h"
+
+#include <inttypes.h>
+#include <errno.h>
+
+static int mtd_spi_eeprom_init(mtd_dev_t *mtd);
+static int mtd_spi_eeprom_read(mtd_dev_t *mtd, void *dest, uint32_t addr,
+                           uint32_t size);
+static int mtd_spi_eeprom_write(mtd_dev_t *mtd, const void *src, uint32_t addr,
+                            uint32_t size);
+static int mtd_spi_eeprom_erase(mtd_dev_t *mtd, uint32_t addr, uint32_t size);
+static int mtd_spi_eeprom_power(mtd_dev_t *mtd, enum mtd_power_state power);
+
+const mtd_desc_t mtd_spi_eeprom_driver = {
+    .init = mtd_spi_eeprom_init,
+    .read = mtd_spi_eeprom_read,
+    .write = mtd_spi_eeprom_write,
+    .erase = mtd_spi_eeprom_erase,
+    .power = mtd_spi_eeprom_power,
+};
+
+static int mtd_spi_eeprom_init(mtd_dev_t *dev)
+{
+    DEBUG("mtd_spi_eeprom_init\n");
+    mtd_spi_eeprom_t *mtd_eeprom = (mtd_spi_eeprom_t*)dev;
+    if (at25xxx_init(mtd_eeprom->spi_eeprom, mtd_eeprom->params) == 0)
+    {
+        dev->pages_per_sector = 1;
+        dev->page_size        = AT25XXX_PARAM_PAGE_SIZE;
+        return 0;
+    }
+    return -EIO;
+}
+
+static int mtd_spi_eeprom_read(mtd_dev_t *dev, void *buff, uint32_t addr,
+                           uint32_t size)
+{
+    DEBUG("mtd_eeprom_read: addr:%" PRIu32 " size:%" PRIu32 "\n", addr, size);
+    mtd_spi_eeprom_t *mtd_eeprom = (mtd_spi_eeprom_t*)dev;
+    size_t res = at25xxx_read(mtd_eeprom->spi_eeprom, addr, buff, size);
+    if (res == size) {
+        return res;
+    }
+    return -EIO;
+}
+
+static int mtd_spi_eeprom_write(mtd_dev_t *dev, const void *buff, uint32_t addr,
+                            uint32_t size)
+{
+    DEBUG("mtd_eeprom_write: addr:%" PRIu32 " size:%" PRIu32 "\n", addr, size);
+    mtd_spi_eeprom_t *mtd_eeprom = (mtd_spi_eeprom_t*)dev;
+    size_t res = at25xxx_write(mtd_eeprom->spi_eeprom, addr,
+                                    buff, size);
+    if (res) {
+        return res;
+    }
+    return -EIO;
+}
+
+static int mtd_spi_eeprom_erase(mtd_dev_t *dev,
+                            uint32_t addr,
+                            uint32_t size)
+{
+    DEBUG("mtd_spi_eeprom_erase: addr:%" PRIu32 " size:%" PRIu32 "\n", addr, size);
+    mtd_spi_eeprom_t *mtd_eeprom = (mtd_spi_eeprom_t*)dev;
+    size_t res = at25xxx_clear(mtd_eeprom->spi_eeprom, addr, size);
+    if (res == size) {
+        return 0;
+    }
+    return -ENOTSUP;
+}
+
+static int mtd_spi_eeprom_power(mtd_dev_t *dev, enum mtd_power_state power)
+{
+    (void)dev;
+    (void)power;
+
+    /* TODO: implement power down of EEPROM (in at25xxx driver?)
+    */
+    return -ENOTSUP; /* currently not supported */
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

add mtd_spi_eeprom driver, which connects the vfs with the EEPROM driver at25xxx via littlefs.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

use RIOT/examples/filesystem for testing. EEPROM will be mounted at MTD_0. for configuration (block size, etc.) use littlefs file descriptor.
for example (using M95M01): 
static littlefs_desc_t fs_desc = {
    .lock = MUTEX_INIT,
    .config = {
        .read_size = 8,
        .prog_size = 8,
        .block_size = 256,
        .block_count = 512,
        .lookahead = 16,
    },
};
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
